### PR TITLE
Add async close support to Dialog and Drawer with updated docs and tests

### DIFF
--- a/docs/content/_demo/dialog/AsynchronouslyClose.demo.tsx
+++ b/docs/content/_demo/dialog/AsynchronouslyClose.demo.tsx
@@ -1,0 +1,66 @@
+'use client'
+
+import {
+  Dialog,
+  DialogTrigger,
+  Button,
+  DialogBody,
+  DialogClose,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+} from '@nex-ui/react'
+import { useState } from 'react'
+
+export default function App() {
+  const [loading, setLoading] = useState(false)
+
+  return (
+    <Dialog>
+      <DialogTrigger>
+        <Button>Open Dialog</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>Dialog Header</DialogHeader>
+        <DialogBody>
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam
+            pulvinar risus non risus hendrerit venenatis. Pellentesque sit amet
+            hendrerit risus, sed porttitor quam.
+          </p>
+          <p>
+            Magna exercitation reprehenderit magna aute tempor cupidatat
+            consequat elit dolor adipisicing. Mollit dolor eiusmod sunt ex
+            incididunt cillum quis. Velit duis sit officia eiusmod Lorem aliqua
+            enim laboris do dolor eiusmod. Et mollit incididunt nisi consectetur
+            esse laborum eiusmod pariatur proident Lorem eiusmod et. Culpa
+            deserunt nostrud ad veniam.
+          </p>
+        </DialogBody>
+        <DialogFooter>
+          <DialogClose>
+            <Button color='red' variant='text'>
+              Cancel
+            </Button>
+          </DialogClose>
+          <DialogClose>
+            <Button
+              loading={loading}
+              onClick={() => {
+                setLoading(true)
+                return new Promise((res) => {
+                  setTimeout(() => {
+                    res(true)
+                    setLoading(false)
+                  }, 2000)
+                })
+              }}
+            >
+              Action
+            </Button>
+          </DialogClose>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/docs/content/_demo/dialog/index.tsx
+++ b/docs/content/_demo/dialog/index.tsx
@@ -18,6 +18,8 @@ import scrollBehaviorCode from './ScrollBehavior.demo?raw'
 import ScrollBehaviorDemo from './ScrollBehavior.demo'
 import customMotionCode from './CustomMotion.demo?raw'
 import CustomMotionDemo from './CustomMotion.demo'
+import AsynchronouslyCloseDemo from './AsynchronouslyClose.demo'
+import asynchronouslyCloseCode from './AsynchronouslyClose.demo?raw'
 
 export const dialog = {
   usage: {
@@ -59,5 +61,9 @@ export const dialog = {
   customMotion: {
     code: customMotionCode,
     demo: <CustomMotionDemo />,
+  },
+  asynchronouslyClose: {
+    code: asynchronouslyCloseCode,
+    demo: <AsynchronouslyCloseDemo />,
   },
 }

--- a/docs/content/_demo/drawer/AsynchronouslyClose.demo.tsx
+++ b/docs/content/_demo/drawer/AsynchronouslyClose.demo.tsx
@@ -1,0 +1,66 @@
+'use client'
+
+import {
+  Drawer,
+  DrawerTrigger,
+  Button,
+  DrawerBody,
+  DrawerClose,
+  DrawerContent,
+  DrawerFooter,
+  DrawerHeader,
+} from '@nex-ui/react'
+import { useState } from 'react'
+
+export default function App() {
+  const [loading, setLoading] = useState(false)
+
+  return (
+    <Drawer>
+      <DrawerTrigger>
+        <Button>Open Drawer</Button>
+      </DrawerTrigger>
+      <DrawerContent>
+        <DrawerHeader>Drawer Header</DrawerHeader>
+        <DrawerBody>
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam
+            pulvinar risus non risus hendrerit venenatis. Pellentesque sit amet
+            hendrerit risus, sed porttitor quam.
+          </p>
+          <p>
+            Magna exercitation reprehenderit magna aute tempor cupidatat
+            consequat elit dolor adipisicing. Mollit dolor eiusmod sunt ex
+            incididunt cillum quis. Velit duis sit officia eiusmod Lorem aliqua
+            enim laboris do dolor eiusmod. Et mollit incididunt nisi consectetur
+            esse laborum eiusmod pariatur proident Lorem eiusmod et. Culpa
+            deserunt nostrud ad veniam.
+          </p>
+        </DrawerBody>
+        <DrawerFooter>
+          <DrawerClose>
+            <Button color='red' variant='text'>
+              Cancel
+            </Button>
+          </DrawerClose>
+          <DrawerClose>
+            <Button
+              loading={loading}
+              onClick={() => {
+                setLoading(true)
+                return new Promise((res) => {
+                  setTimeout(() => {
+                    res(true)
+                    setLoading(false)
+                  }, 2000)
+                })
+              }}
+            >
+              Action
+            </Button>
+          </DrawerClose>
+        </DrawerFooter>
+      </DrawerContent>
+    </Drawer>
+  )
+}

--- a/docs/content/_demo/drawer/index.tsx
+++ b/docs/content/_demo/drawer/index.tsx
@@ -14,6 +14,8 @@ import controlledCode from './Controlled.demo?raw'
 import ControlledDemo from './Controlled.demo'
 import customMotionCode from './CustomMotion.demo?raw'
 import CustomMotionDemo from './CustomMotion.demo'
+import AsynchronouslyCloseDemo from './AsynchronouslyClose.demo'
+import asynchronouslyCloseCode from './AsynchronouslyClose.demo?raw'
 
 export const drawer = {
   usage: {
@@ -47,5 +49,9 @@ export const drawer = {
   customMotion: {
     code: customMotionCode,
     demo: <CustomMotionDemo />,
+  },
+  asynchronouslyClose: {
+    code: asynchronouslyCloseCode,
+    demo: <AsynchronouslyCloseDemo />,
   },
 }

--- a/docs/content/en/docs/components/dialog.mdx
+++ b/docs/content/en/docs/components/dialog.mdx
@@ -17,54 +17,60 @@ Display a dialog with custom content that requires attention or provides additio
 
 ### HideBackdrop
 
-Set the `hideBackdrop` property of `Dialog` to `true` to hide the dialog's background overlay.
+Set the `hideBackdrop` property of Dialog to `true` to hide the dialog's background overlay.
 
 <Example {...dialog.hideBackdrop} />
 
 ### PreventScroll
 
-Set the `preventScroll` property of `Dialog` to `true` to prevent page scrolling when the dialog is open.
+Set the `preventScroll` property of Dialog to `true` to prevent page scrolling when the dialog is open.
 
 <Example {...dialog.preventScroll} />
 
 ### KeepMounted
 
-Set the `keepMounted` property of `Dialog` to `true` to keep the dialog content mounted when closed.
+Set the `keepMounted` property of Dialog to `true` to keep the dialog content mounted when closed.
 
 <Example {...dialog.keepMounted} />
 
 ### Sizes
 
-Use the `size` property of `DialogContent` to set the maximum width of the dialog, defaults to `md`.
+Use the `size` property of DialogContent to set the maximum width of the dialog, defaults to `md`.
 
 <Example {...dialog.sizes} />
 
 ### FullScreen
 
-Set the `fullScreen` property of `DialogContent` to `true` to make the dialog full-screen.
+Set the `fullScreen` property of DialogContent to `true` to make the dialog full-screen.
 
 <Example {...dialog.fullScreen} />
 
 ### Placements
 
-Use the `placement` property of `DialogContent` to set the display position of the dialog, defaults to `top`.
+Use the `placement` property of DialogContent to set the display position of the dialog, defaults to `top`.
 
 <Example {...dialog.placements} />
 
 ### Custom Motion
 
-Use the `motionProps` property of `DialogContent` to customize the animation effects for `visible` / `hidden`.
+Use the `motionProps` property of DialogContent to customize the animation effects for `visible` / `hidden`.
 
 <Example {...dialog.customMotion} />
 
 ### Overflow Scroll
 
-Use the `scroll` property of `DialogContent` to control the scrolling behavior of dialog content.
+Use the `scroll` property of DialogContent to control the scrolling behavior of dialog content.
 
 - `inside`: Content scrolls inside the dialog.
 - `outside`: Content scrolls outside the dialog.
 
 <Example {...dialog.scrollBehavior} />
+
+### Asynchronously Close
+
+DialogClose supports asynchronously closing the dialog. The `onClick` event of its `children` can return a `Promise` , and the dialog will close when the `Promise` is resolved.
+
+<Example {...dialog.asynchronouslyClose} />
 
 ### Controlled Dialog
 
@@ -145,6 +151,12 @@ Dialog props inherit the props of `as` (by default, `m.div`).
       description:
         'If true, the dialog will restore focus to previously focused element once the modal is hidden or unmounted.',
       default: 'true',
+    },
+    {
+      prop: 'onClose',
+      type: '() => void',
+      description:
+        'Callback function that is called when the dialog is closed.',
     },
     {
       prop: 'as',
@@ -374,7 +386,8 @@ DialogFooter props inherit the props of `as` (by default,`'div'`).
     {
       prop: 'children',
       type: 'ReactNode',
-      description: 'The element that triggers the dialog to open.',
+      description:
+        'The element that triggers the dialog to open, must support `onClick` event.',
     },
   ]}
 />
@@ -386,7 +399,8 @@ DialogFooter props inherit the props of `as` (by default,`'div'`).
     {
       prop: 'children',
       type: 'ReactNode',
-      description: 'The element that triggers the dialog to close',
+      description:
+        'The element that triggers the dialog to close, must support `onClick` event.',
     },
   ]}
 />

--- a/docs/content/en/docs/components/drawer.mdx
+++ b/docs/content/en/docs/components/drawer.mdx
@@ -15,41 +15,47 @@ Drawer is a component that slides in from the side of the screen.
 
 ### HideBackdrop
 
-Set the `hideBackdrop` property of `Drawer` to `true` to hide the background overlay.
+Set the `hideBackdrop` property of Drawer to `true` to hide the background overlay.
 
 <Example {...drawer.hideBackdrop} />
 
 ### PreventScroll
 
-Set the `preventScroll` property of `Drawer` to `true` to prevent page scrolling when the drawer is open.
+Set the `preventScroll` property of Drawer to `true` to prevent page scrolling when the drawer is open.
 
 <Example {...drawer.preventScroll} />
 
 ### KeepMounted
 
-Set the `keepMounted` property of `Drawer` to `true` to keep the drawer content mounted when closed.
+Set the `keepMounted` property of Drawer to `true` to keep the drawer content mounted when closed.
 
 <Example {...drawer.keepMounted} />
 
 ### Sizes
 
-Use the `size` property of `DrawerContent` to set the size of the drawer, defaults to `md`.
+Use the `size` property of DrawerContent to set the size of the drawer, defaults to `md`.
 
 <Example {...drawer.sizes} />
 
 ### Placements
 
-Use the `placement` property of `DrawerContent` to set the display position of the drawer, defaults to `right`.
+Use the `placement` property of DrawerContent to set the display position of the drawer, defaults to `right`.
 
 <Example {...drawer.placements} />
 
 ### Custom Motion
 
-Use the `motionProps` property of `DrawerContent` to customize the animation effects for showing/hiding the drawer.
+Use the `motionProps` property of DrawerContent to customize the animation effects for showing/hiding the drawer.
 
 <Example {...drawer.customMotion} />
 
-### Controlled
+### Asynchronously Close
+
+DrawerClose supports asynchronously closing the drawer. The `onClick` event of its `children` can return a `Promise`, and the drawer will close after the `Promise` is resolved.
+
+<Example {...drawer.asynchronouslyClose} />
+
+### Controlled Drawer
 
 <Example {...drawer.controlled} />
 
@@ -128,6 +134,12 @@ Drawer props inherit the props of `as` (by default, `m.div`).
       description:
         'If true, the drawer will restore focus to previously focused element once the modal is hidden or unmounted.',
       default: 'true',
+    },
+    {
+      prop: 'onClose',
+      type: '() => void',
+      description:
+        'Callback function that is called when the drawer is closed.',
     },
     {
       prop: 'as',
@@ -345,7 +357,8 @@ DrawerFooter props inherit the props of `as` (by default,`'div'`).
     {
       prop: 'children',
       type: 'ReactNode',
-      description: 'The element that triggers the drawer to open.',
+      description:
+        'The element that triggers the drawer to open, must support `onClick` event.',
     },
   ]}
 />
@@ -357,7 +370,8 @@ DrawerFooter props inherit the props of `as` (by default,`'div'`).
     {
       prop: 'children',
       type: 'ReactNode',
-      description: 'The element that triggers the drawer to close',
+      description:
+        'The element that triggers the drawer to close, must support `onClick` event.',
     },
   ]}
 />

--- a/docs/content/zh/docs/components/dialog.mdx
+++ b/docs/content/zh/docs/components/dialog.mdx
@@ -17,54 +17,60 @@ Dialog 显示需要关注或提供额外信息的自定义内容。
 
 ### HideBackdrop
 
-设置 `Dialog` 的 `hideBackdrop` 属性为 `true` 可以隐藏 Dialog 的背景遮罩。
+设置 Dialog 的 `hideBackdrop` 属性为 `true` 可以隐藏 Dialog 的背景遮罩。
 
 <Example {...dialog.hideBackdrop} />
 
 ### PreventScroll
 
-设置 `Dialog` 的 `preventScroll` 属性为 `true` 可以限制 Dialog 打开时页面滚动。
+设置 Dialog 的 `preventScroll` 属性为 `true` 可以限制 Dialog 打开时页面滚动。
 
 <Example {...dialog.preventScroll} />
 
 ### KeepMounted
 
-设置 `Dialog` 的 `keepMounted` 属性为 `true` 可以保持 Dialog 内容在关闭时仍然挂载。
+设置 Dialog 的 `keepMounted` 属性为 `true` 可以保持 Dialog 内容在关闭时仍然挂载。
 
 <Example {...dialog.keepMounted} />
 
 ### Sizes
 
-使用 `DialogContent` 的 `size` 属性可以设置 Dialog 的大小，默认为 `md`。
+DialogContent 的 `size` 属性可以设置 Dialog 的大小，默认为 `md`。
 
 <Example {...dialog.sizes} />
 
 ### FullScreen
 
-设置 `DialogContent` 的 `fullScreen` 属性为 `true` 可以使 Dialog 全屏显示。
+设置 DialogContent 的 `fullScreen` 属性为 `true` 可以使 Dialog 全屏显示。
 
 <Example {...dialog.fullScreen} />
 
 ### Placements
 
-使用 `DialogContent` 的 `placement` 属性可以设置 Dialog 的显示位置，默认为 `top`。
+DialogContent 的 `placement` 属性可以设置 Dialog 的显示位置，默认为 `top`。
 
 <Example {...dialog.placements} />
 
 ### Custom Motion
 
-使用 `DialogContent` 的 `motionProps` 属性可以自定义 `visible` / `hidden` 的动画效果。
+DialogContent 的 `motionProps` 属性可以自定义 `visible` / `hidden` 的动画效果。
 
 <Example {...dialog.customMotion} />
 
 ### Overflow Scroll
 
-使用 `DialogContent` 的 `scroll` 属性可以控制 Dialog 内容的滚动行为。
+DialogContent 的 `scroll` 属性可以控制 Dialog 内容的滚动行为。
 
 - `inside`: 内容在 Dialog 内部滚动。
 - `outside`: 内容在 Dialog 外部滚动。
 
 <Example {...dialog.scrollBehavior} />
+
+### Asynchronously Close
+
+DialogClose 支持异步关闭 Dialog ，其 `children` 的 `onClick` 事件可返回一个 `Promise` , Dialog 会在 `Promise` 被 `resolve` 后关闭。
+
+<Example {...dialog.asynchronouslyClose} />
 
 ### Controlled Dialog
 
@@ -144,6 +150,11 @@ Dialog Props 继承 `as` (默认为 `m.div`) 的 Props。
       type: 'boolean',
       description: '是否在 Dialog 关闭时恢复焦点到之前聚焦的元素。',
       default: 'true',
+    },
+    {
+      prop: 'onClose',
+      type: '() => void',
+      description: 'Dialog 关闭时执行的回调函数。',
     },
     {
       prop: 'as',
@@ -373,7 +384,7 @@ DialogFooter Props 继承 `as` (默认为 `'div'`) 的 Props。
     {
       prop: 'children',
       type: 'ReactNode',
-      description: '触发 Dialog 打开的元素。',
+      description: '触发 Dialog 打开的元素，需支持 `onClick` 事件。',
     },
   ]}
 />
@@ -385,7 +396,7 @@ DialogFooter Props 继承 `as` (默认为 `'div'`) 的 Props。
     {
       prop: 'children',
       type: 'ReactNode',
-      description: '触发 Dialog 关闭的元素。',
+      description: '触发 Dialog 关闭的元素，需支持 `onClick` 事件。',
     },
   ]}
 />

--- a/docs/content/zh/docs/components/drawer.mdx
+++ b/docs/content/zh/docs/components/drawer.mdx
@@ -17,41 +17,47 @@ Drawer 是一个从屏幕边缘滑出的浮层面板。
 
 ### HideBackdrop
 
-设置 `Drawer` 的 `hideBackdrop` 属性为 `true` 可以隐藏 Drawer 的背景遮罩。
+设置 Drawer 的 `hideBackdrop` 属性为 `true` 可以隐藏 Drawer 的背景遮罩。
 
 <Example {...drawer.hideBackdrop} />
 
 ### PreventScroll
 
-设置 `Drawer` 的 `preventScroll` 属性为 `true` 可以限制 Drawer 打开时页面滚动。
+设置 Drawer 的 `preventScroll` 属性为 `true` 可以限制 Drawer 打开时页面滚动。
 
 <Example {...drawer.preventScroll} />
 
 ### KeepMounted
 
-设置 `Drawer` 的 `keepMounted` 属性为 `true` 可以保持 Drawer 内容在关闭时仍然挂载。
+设置 Drawer 的 `keepMounted` 属性为 `true` 可以保持 Drawer 内容在关闭时仍然挂载。
 
 <Example {...drawer.keepMounted} />
 
 ### Sizes
 
-使用 `DrawerContent` 的 `size` 属性可以设置 Drawer 的大小，默认为 `md`。
+DrawerContent 的 `size` 属性可以设置 Drawer 的大小，默认为 `md`。
 
 <Example {...drawer.sizes} />
 
 ### Placements
 
-使用 `DrawerContent` 的 `placement` 属性可以设置 Drawer 的显示位置，默认为 `right`。
+DrawerContent 的 `placement` 属性可以设置 Drawer 的显示位置，默认为 `right`。
 
 <Example {...drawer.placements} />
 
 ### Custom Motion
 
-使用 `DrawerContent` 的 `motionProps` 属性可以自定义 Drawer 显示/隐藏的动画效果。
+DrawerContent 的 `motionProps` 属性可以自定义 Drawer 显示/隐藏的动画效果。
 
 <Example {...drawer.customMotion} />
 
-### Controlled
+### Asynchronously Close
+
+DrawerClose 支持异步关闭 Drawer，其 `children` 的 `onClick` 事件可返回一个 `Promise`，Drawer 会在 `Promise` 被 `resolve` 后关闭。
+
+<Example {...drawer.asynchronouslyClose} />
+
+### Controlled Drawer
 
 <Example {...drawer.controlled} />
 
@@ -129,6 +135,11 @@ Drawer Props 继承 `as` (默认为 `m.div`) 的 Props。
       type: 'boolean',
       description: '是否在 Drawer 关闭时恢复焦点到之前聚焦的元素。',
       default: 'true',
+    },
+    {
+      prop: 'onClose',
+      type: '() => void',
+      description: 'Drawer 关闭时执行的回调函数。',
     },
     {
       prop: 'as',
@@ -346,7 +357,7 @@ DrawerFooter Props 继承 `as` (默认为 `'div'`) 的 Props。
     {
       prop: 'children',
       type: 'ReactNode',
-      description: '触发 Drawer 打开的元素。',
+      description: '触发 Drawer 打开的元素，需支持 `onClick` 事件。',
     },
   ]}
 />
@@ -358,7 +369,7 @@ DrawerFooter Props 继承 `as` (默认为 `'div'`) 的 Props。
     {
       prop: 'children',
       type: 'ReactNode',
-      description: '触发 Drawer 关闭的元素。',
+      description: '触发 Drawer 关闭的元素，需支持 `onClick` 事件。',
     },
   ]}
 />

--- a/packages/react/src/components/accordion/AccordionItem.tsx
+++ b/packages/react/src/components/accordion/AccordionItem.tsx
@@ -4,7 +4,7 @@ import * as m from 'motion/react-m'
 import { useEvent } from '@nex-ui/hooks'
 import { ChevronDownOutlined } from '@nex-ui/icons'
 import { LazyMotion, AnimatePresence } from 'motion/react'
-import { useEffect, useId, useMemo, useRef } from 'react'
+import { useId, useMemo, useRef } from 'react'
 import { useNexUI } from '../provider'
 import { accordionItemRecipe } from '../../theme/recipes'
 import { ButtonBase } from '../buttonBase'
@@ -268,8 +268,6 @@ export const AccordionItem = <RootComponent extends ElementType = 'div'>(
       ...indicatorMotionProps,
     },
   })
-
-  useEffect(() => {}, [])
 
   return (
     <LazyMotion features={motionFeatures}>

--- a/packages/react/src/components/dialog/Dialog.tsx
+++ b/packages/react/src/components/dialog/Dialog.tsx
@@ -57,6 +57,7 @@ export const Dialog = <
     closeOnEscape,
     closeOnInteractBackdrop,
     preventScroll,
+    onClose,
     hideBackdrop,
     ...remainingProps
   } = props
@@ -71,6 +72,7 @@ export const Dialog = <
       keepMounted={keepMounted}
       preventScroll={preventScroll}
       closeOnEscape={closeOnEscape}
+      onClose={onClose}
       closeOnInteractOutside={!hideBackdrop && closeOnInteractBackdrop}
     >
       <Provider hideBackdrop={hideBackdrop} {...remainingProps}>

--- a/packages/react/src/components/dialog/__tests__/Dialog.test.tsx
+++ b/packages/react/src/components/dialog/__tests__/Dialog.test.tsx
@@ -6,8 +6,6 @@ import {
   DialogHeader,
   DialogFooter,
   DialogBody,
-  DialogTrigger,
-  DialogClose,
 } from '../index'
 import {
   dialogBodyClasses,
@@ -200,52 +198,6 @@ describe('Dialog', () => {
 
       const dialogFooter = getByTestId('dialog-footer')
       expect(dialogFooter).toHaveClass(dialogFooterClasses.root)
-    })
-  })
-
-  describe('DialogTrigger', () => {
-    it('should open when the DialogTrigger is clicked', async () => {
-      const { getByTestId, queryByTestId, user } =
-        await renderWithNexUIProvider(
-          <Dialog>
-            <DialogTrigger>
-              <button data-testid='open-button'>Open Dialog</button>
-            </DialogTrigger>
-            <DialogContent data-testid='dialog-content' />
-          </Dialog>,
-          {
-            useAct: true,
-          },
-        )
-
-      expect(queryByTestId('dialog-content')).not.toBeInTheDocument()
-      const openButton = getByTestId('open-button')
-
-      await user.click(openButton)
-      expect(queryByTestId('dialog-content')).toBeInTheDocument()
-    })
-  })
-
-  describe('DialogClose', () => {
-    it('should close when the DiglogClose is clicked', async () => {
-      const { getByTestId, queryByTestId, user } =
-        await renderWithNexUIProvider(
-          <Dialog defaultOpen>
-            <DialogClose>
-              <button data-testid='close-button'>Close Dialog</button>
-            </DialogClose>
-            <DialogContent data-testid='dialog-content' />
-          </Dialog>,
-          {
-            useAct: true,
-          },
-        )
-
-      expect(queryByTestId('dialog-content')).toBeInTheDocument()
-      const closeButton = getByTestId('close-button')
-
-      await user.click(closeButton)
-      expect(queryByTestId('dialog-content')).not.toBeInTheDocument()
     })
   })
 })

--- a/packages/react/src/components/dialog/types.ts
+++ b/packages/react/src/components/dialog/types.ts
@@ -105,6 +105,11 @@ type DialogOwnProps<RootComponent extends ElementType> = {
    * @default true
    */
   closeOnInteractBackdrop?: boolean
+
+  /**
+   * Callback function that is called when the dialog is closed.
+   */
+  onClose?: () => void
 }
 
 export interface DialogPropsOverrides {}

--- a/packages/react/src/components/drawer/Drawer.tsx
+++ b/packages/react/src/components/drawer/Drawer.tsx
@@ -58,6 +58,7 @@ export const Drawer = <
     closeOnInteractBackdrop,
     preventScroll,
     hideBackdrop,
+    onClose,
     ...remainingProps
   } = props
 
@@ -71,6 +72,7 @@ export const Drawer = <
       keepMounted={keepMounted}
       preventScroll={preventScroll}
       closeOnEscape={closeOnEscape}
+      onClose={onClose}
       closeOnInteractOutside={!hideBackdrop && closeOnInteractBackdrop}
     >
       <Provider hideBackdrop={hideBackdrop} {...remainingProps}>

--- a/packages/react/src/components/drawer/__tests__/Drawer.test.tsx
+++ b/packages/react/src/components/drawer/__tests__/Drawer.test.tsx
@@ -6,8 +6,6 @@ import {
   DrawerContent,
   DrawerHeader,
   DrawerFooter,
-  DrawerTrigger,
-  DrawerClose,
 } from '../index'
 import {
   drawerClasses,
@@ -200,52 +198,6 @@ describe('Drawer', () => {
 
       const drawerFooter = getByTestId('drawer-footer')
       expect(drawerFooter).toHaveClass(drawerFooterClasses.root)
-    })
-  })
-
-  describe('DrawerTrigger', () => {
-    it('should open when the DrawerTrigger is clicked', async () => {
-      const { getByTestId, queryByTestId, user } =
-        await renderWithNexUIProvider(
-          <Drawer>
-            <DrawerTrigger>
-              <button data-testid='open-button'>Open Drawer</button>
-            </DrawerTrigger>
-            <DrawerContent data-testid='drawer-content' />
-          </Drawer>,
-          {
-            useAct: true,
-          },
-        )
-
-      expect(queryByTestId('drawer-content')).not.toBeInTheDocument()
-      const openButton = getByTestId('open-button')
-
-      await user.click(openButton)
-      expect(queryByTestId('drawer-content')).toBeInTheDocument()
-    })
-  })
-
-  describe('DrawerClose', () => {
-    it('should close when the DiglogClose is clicked', async () => {
-      const { getByTestId, queryByTestId, user } =
-        await renderWithNexUIProvider(
-          <Drawer defaultOpen>
-            <DrawerClose>
-              <button data-testid='close-button'>Close Drawer</button>
-            </DrawerClose>
-            <DrawerContent data-testid='drawer-content' />
-          </Drawer>,
-          {
-            useAct: true,
-          },
-        )
-
-      expect(queryByTestId('drawer-content')).toBeInTheDocument()
-      const closeButton = getByTestId('close-button')
-
-      await user.click(closeButton)
-      expect(queryByTestId('drawer-content')).not.toBeInTheDocument()
     })
   })
 })

--- a/packages/react/src/components/drawer/types.ts
+++ b/packages/react/src/components/drawer/types.ts
@@ -105,6 +105,11 @@ type DrawerOwnProps<RootComponent extends ElementType> = {
    * @default true
    */
   restoreFocus?: boolean
+
+  /**
+   * Callback function that is called when the drawer is closed.
+   */
+  onClose?: () => void
 }
 
 export type DrawerOwnerState<

--- a/packages/react/src/components/modal/Modal.tsx
+++ b/packages/react/src/components/modal/Modal.tsx
@@ -1,13 +1,22 @@
 'use client'
 
+import { useEffect, useMemo, useRef } from 'react'
 import { useControlledState } from '@nex-ui/hooks'
 import { ModalProvider } from './ModalContext'
 import type { ModalProps } from './types'
+
+/**
+ * Modal is a lower-level construct that is leveraged by the following components:
+ *
+ * - Dialog
+ * - Drawer
+ */
 
 export const Modal = (props: ModalProps) => {
   const {
     children,
     container,
+    onClose,
     onOpenChange,
     open: openProp,
     restoreFocus = true,
@@ -24,18 +33,41 @@ export const Modal = (props: ModalProps) => {
     onOpenChange,
   )
 
-  const rootProps = {
-    setOpen,
-    restoreFocus,
-    closeOnEscape,
-    open,
-    keepMounted,
-    defaultOpen,
-    closeOnInteractOutside,
-    onOpenChange,
-    preventScroll,
-    container,
-  }
+  const prevOpenRef = useRef(open)
+
+  const rootProps = useMemo(
+    () => ({
+      setOpen,
+      restoreFocus,
+      closeOnEscape,
+      open,
+      keepMounted,
+      defaultOpen,
+      closeOnInteractOutside,
+      onOpenChange,
+      preventScroll,
+      container,
+    }),
+    [
+      setOpen,
+      restoreFocus,
+      closeOnEscape,
+      open,
+      keepMounted,
+      defaultOpen,
+      closeOnInteractOutside,
+      onOpenChange,
+      preventScroll,
+      container,
+    ],
+  )
+
+  useEffect(() => {
+    if (prevOpenRef.current && !open) {
+      onClose?.()
+    }
+    prevOpenRef.current = open
+  }, [onClose, open])
 
   return <ModalProvider value={rootProps}>{children}</ModalProvider>
 }

--- a/packages/react/src/components/modal/ModalClose.tsx
+++ b/packages/react/src/components/modal/ModalClose.tsx
@@ -1,20 +1,33 @@
 'use client'
 
-import { chain } from '@nex-ui/utils'
 import { cloneElement, isValidElement } from 'react'
 import { useModal } from './ModalContext'
 import type { ModalCloseProps } from './types'
 
 export const ModalClose = ({ children }: ModalCloseProps) => {
   const { setOpen } = useModal()
+
   return isValidElement(children)
     ? cloneElement<any>(children, {
-        onClick: chain(
-          () => {
-            setOpen(false)
-          },
-          (children as React.ReactElement<any>)?.props?.onClick,
-        ),
+        onClick: () => {
+          const onClick = (children as React.ReactElement<any>)?.props?.onClick
+
+          if (onClick) {
+            const result = onClick()
+
+            // Check if the result is a Promise
+            if (
+              result &&
+              result instanceof Promise &&
+              typeof result.then === 'function'
+            ) {
+              result.then(() => setOpen(false)).catch(() => {})
+
+              return
+            }
+          }
+          setOpen(false)
+        },
       })
     : children
 }

--- a/packages/react/src/components/modal/__tests__/ModalClose.test.tsx
+++ b/packages/react/src/components/modal/__tests__/ModalClose.test.tsx
@@ -1,0 +1,114 @@
+import { fireEvent, waitFor, act } from '@testing-library/react'
+import { renderWithNexUIProvider } from '~/tests/shared'
+import { Modal, ModalPanel, ModalRoot, ModalClose } from '../index'
+
+describe('ModalClose', () => {
+  it('should close when the ModalClose is clicked', async () => {
+    const { getByTestId, queryByTestId, user } = await renderWithNexUIProvider(
+      <Modal defaultOpen>
+        <ModalClose>
+          <button data-testid='close-button'>Close Modal</button>
+        </ModalClose>
+        <ModalRoot data-testid='modal-root'>
+          <ModalPanel />
+        </ModalRoot>
+      </Modal>,
+      {
+        useAct: true,
+      },
+    )
+
+    expect(queryByTestId('modal-root')).toBeInTheDocument()
+    const closeButton = getByTestId('close-button')
+
+    await user.click(closeButton)
+    expect(queryByTestId('modal-root')).toBeNull()
+  })
+
+  it("should return children as-is when ModalClose's children is not a valid React element", async () => {
+    const { container } = await renderWithNexUIProvider(
+      <Modal>
+        <ModalClose>Child</ModalClose>
+      </Modal>,
+      {
+        useAct: true,
+      },
+    )
+
+    expect(container.textContent).toBe('Child')
+  })
+
+  it("should async close when the children's onClick returns a resolved Promise", async () => {
+    jest.useFakeTimers()
+
+    const { getByTestId, queryByTestId } = await renderWithNexUIProvider(
+      <Modal defaultOpen>
+        <ModalClose>
+          <button
+            data-testid='close-button'
+            onClick={() => {
+              return new Promise<void>((res) => {
+                setTimeout(() => {
+                  res()
+                }, 2000)
+              })
+            }}
+          >
+            Close Modal
+          </button>
+        </ModalClose>
+        <ModalRoot data-testid='modal-root'>
+          <ModalPanel />
+        </ModalRoot>
+      </Modal>,
+      {
+        useAct: true,
+      },
+    )
+
+    expect(queryByTestId('modal-root')).toBeInTheDocument()
+    const closeButton = getByTestId('close-button')
+
+    fireEvent.click(closeButton)
+
+    jest.runAllTimers()
+
+    await waitFor(() => {
+      expect(queryByTestId('modal-root')).toBeNull()
+    })
+
+    jest.useRealTimers()
+  })
+
+  it('should not close when the children onClick return a rejected Promise', async () => {
+    const { getByTestId, queryByTestId, user } = await renderWithNexUIProvider(
+      <Modal defaultOpen>
+        <ModalClose>
+          <button
+            data-testid='close-button'
+            onClick={() => {
+              return Promise.reject()
+            }}
+          >
+            Close Modal
+          </button>
+        </ModalClose>
+        <ModalRoot data-testid='modal-root'>
+          <ModalPanel />
+        </ModalRoot>
+      </Modal>,
+      {
+        useAct: true,
+      },
+    )
+
+    expect(queryByTestId('modal-root')).toBeInTheDocument()
+    const closeButton = getByTestId('close-button')
+
+    await act(() => user.click(closeButton))
+
+    await new Promise((resolve) => setTimeout(resolve, 500))
+
+    expect(queryByTestId('modal-root')).toBeInTheDocument()
+  })
+})

--- a/packages/react/src/components/modal/__tests__/ModalTrigger.test.tsx
+++ b/packages/react/src/components/modal/__tests__/ModalTrigger.test.tsx
@@ -1,0 +1,39 @@
+import { renderWithNexUIProvider } from '~/tests/shared'
+import { Modal, ModalPanel, ModalRoot, ModalTrigger } from '../index'
+
+describe('ModalTrigger', () => {
+  it('should open when the ModalTrigger is clicked', async () => {
+    const { getByTestId, queryByTestId, user } = await renderWithNexUIProvider(
+      <Modal>
+        <ModalTrigger>
+          <button data-testid='open-button'>Open Modal</button>
+        </ModalTrigger>
+        <ModalRoot data-testid='modal-root'>
+          <ModalPanel />
+        </ModalRoot>
+      </Modal>,
+      {
+        useAct: true,
+      },
+    )
+
+    expect(queryByTestId('modal-root')).toBeNull()
+    const openButton = getByTestId('open-button')
+
+    await user.click(openButton)
+    expect(queryByTestId('modal-root')).toBeInTheDocument()
+  })
+
+  it("should return children as-is when ModalTrigger's children is not a valid React element", async () => {
+    const { container } = await renderWithNexUIProvider(
+      <Modal>
+        <ModalTrigger>Child</ModalTrigger>
+      </Modal>,
+      {
+        useAct: true,
+      },
+    )
+
+    expect(container.textContent).toBe('Child')
+  })
+})

--- a/packages/react/src/components/modal/types.ts
+++ b/packages/react/src/components/modal/types.ts
@@ -65,6 +65,11 @@ export type ModalProps = {
    * @default true
    */
   restoreFocus?: boolean
+
+  /**
+   * Callback function that is called when the modal is closed.
+   */
+  onClose?: () => void
 }
 
 // ------------- ModalTrigger -------------


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for asynchronous close actions in Dialog and Drawer components, allowing dialogs and drawers to close only after async operations complete.
  * Introduced new demos showcasing asynchronous close behavior for Dialog and Drawer.
  * Added optional onClose callback prop to Dialog, Drawer, and Modal components, triggered when they are closed.

* **Documentation**
  * Updated Dialog and Drawer documentation (English and Chinese) to describe asynchronous close support and the new onClose prop.
  * Improved clarity and consistency in component prop descriptions and section titles.

* **Tests**
  * Added and updated tests to verify asynchronous close behavior and the onClose callback for Modal, Dialog, and Drawer components.
  * Refined and reorganized test coverage by removing tests for trigger and close components in Dialog and Drawer, and adding focused tests for ModalClose and ModalTrigger components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->