### PR TITLE
Add disableAnimation props to Card and recipe components

### DIFF
--- a/docs/content/en/docs/components/card.mdx
+++ b/docs/content/en/docs/components/card.mdx
@@ -124,6 +124,11 @@ Card inherits the props of `as` (by default, `'div'`).
       type: 'boolean',
       description: 'If true, enables a hover effect on the Card.',
     },
+    {
+      prop: 'disableAnimation',
+      type: 'boolean',
+      description: 'If true, disables the animation for the Card on hover.',
+    },
   ]}
 />
 
@@ -323,6 +328,18 @@ CardActionArea inherits the props of `as` (by default, `'button'`).
       prop: 'ref',
       type: 'Ref',
       description: 'Ref for forwarding to the root.',
+    },
+    {
+      prop: 'disabled',
+      type: 'boolean',
+      default: 'false',
+      description: 'If true, disables the CardActionArea.',
+    },
+    {
+      prop: 'disableRipple',
+      type: 'boolean',
+      default: 'false',
+      description: 'If true, disables the ripple effect on click.',
     },
   ]}
 />

--- a/docs/content/zh/docs/components/card.mdx
+++ b/docs/content/zh/docs/components/card.mdx
@@ -124,6 +124,12 @@ Card 继承 `as` (默认为 `'div'`) 的 Props。
       default: 'false',
       description: 'Card 是否显示悬停效果。',
     },
+    {
+      prop: 'disableAnimation',
+      type: 'boolean',
+      default: 'false',
+      description: '是否禁用悬停时的过渡效果。',
+    },
   ]}
 />
 
@@ -323,6 +329,18 @@ CardActionArea 继承 `as` (默认为 `'button'`) 的 Props。
       prop: 'ref',
       type: 'Ref',
       description: 'Ref 用于转发到根元素。',
+    },
+    {
+      prop: 'disabled',
+      type: 'boolean',
+      default: 'false',
+      description: 'CardActionArea 是否禁用。',
+    },
+    {
+      prop: 'disableRipple',
+      type: 'boolean',
+      default: 'false',
+      description: '是否禁用点击时的涟漪效果。',
     },
   ]}
 />

--- a/notes/todo.md
+++ b/notes/todo.md
@@ -34,5 +34,3 @@
 11. 重构基础组件的 API，尽量减少 Context 的使用
 
 18. 阻止事件的执行，目前有两种形式，1. 传递 prop 2. 使用 event.preventDefault()，是否统一 API ？
-
-19. 基于 Poper 构建的组件，motionProps 的 placement 非计算后的

--- a/packages/react/src/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/packages/react/src/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
@@ -47,6 +47,7 @@ exports[`Breadcrumb should render with default props 1`] = `
   -ms-user-select: none;
   user-select: none;
   border-radius: 2px;
+  white-space: nowrap;
   font-size: var(--nui-font-sizes-md);
   -webkit-transition: var(--nui-transitions-colors);
   transition: var(--nui-transitions-colors);
@@ -102,6 +103,7 @@ exports[`Breadcrumb should render with default props 1`] = `
   -ms-user-select: none;
   user-select: none;
   border-radius: 2px;
+  white-space: nowrap;
   font-size: var(--nui-font-sizes-md);
   -webkit-transition: var(--nui-transitions-colors);
   transition: var(--nui-transitions-colors);

--- a/packages/react/src/components/card/Card.tsx
+++ b/packages/react/src/components/card/Card.tsx
@@ -26,6 +26,7 @@ export function Card<RootComponent extends ElementType = 'div'>(
     radius = 'md',
     hoverable = false,
     blurred = false,
+    disableAnimation = false,
     ...remainingProps
   } = props
 
@@ -35,6 +36,7 @@ export function Card<RootComponent extends ElementType = 'div'>(
     blurred,
     shadow,
     radius,
+    disableAnimation,
   }
 
   const slotClasses = useSlotClasses({
@@ -58,6 +60,7 @@ export function Card<RootComponent extends ElementType = 'div'>(
       radius,
       hoverable,
       blurred,
+      disableAnimation,
     },
   })
 

--- a/packages/react/src/components/card/CardActionArea.tsx
+++ b/packages/react/src/components/card/CardActionArea.tsx
@@ -22,10 +22,21 @@ export function CardActionArea<RootComponent extends ElementType = 'button'>(
     props: inProps,
   })
 
-  const { children, disabled, ...remainingProps } = props
+  const {
+    children,
+    disabled = false,
+    disableRipple = false,
+    ...remainingProps
+  } = props
+
+  const ownerState = {
+    ...props,
+    disabled,
+    disableRipple,
+  }
 
   const style = useRecipeStyles({
-    ownerState: props,
+    ownerState,
     name: 'CardActionArea',
     recipe: cardActionArea,
   })
@@ -44,12 +55,12 @@ export function CardActionArea<RootComponent extends ElementType = 'button'>(
       disabled,
     },
     dataAttrs: {
-      disabled,
+      disableRipple,
     },
   })
 
   return (
-    <Ripple disabled={disabled}>
+    <Ripple disabled={disableRipple || disabled}>
       <CardActionAreaRoot {...getCardActionAreaProps()}>
         {children}
       </CardActionAreaRoot>

--- a/packages/react/src/components/card/__stories__/Card.stories.tsx
+++ b/packages/react/src/components/card/__stories__/Card.stories.tsx
@@ -55,6 +55,9 @@ const meta = {
     hoverable: {
       control: 'boolean',
     },
+    disableAnimation: {
+      control: 'boolean',
+    },
   },
   render: (props) => {
     return (
@@ -105,7 +108,7 @@ export function WithActionArea(props: CardProps) {
   return (
     <Card {...props}>
       <CardHeaderTemplate />
-      <CardActionArea>
+      <CardActionArea disableRipple>
         <CardBody>This action area is clickable.</CardBody>
       </CardActionArea>
     </Card>

--- a/packages/react/src/components/card/__tests__/CardActionArea.test.tsx
+++ b/packages/react/src/components/card/__tests__/CardActionArea.test.tsx
@@ -5,6 +5,7 @@ import {
   testRootClassName,
   testVariantDataAttrs,
 } from '~/tests/shared'
+import { fireEvent } from '@testing-library/react'
 import { CardActionArea } from '../index'
 import { cardActionAreaClasses } from './classes'
 
@@ -27,7 +28,7 @@ describe('CardActionArea', () => {
 
   it('should handle click events when not disabled', async () => {
     const handleClick = jest.fn()
-    const { getByRole, user } = await renderWithNexUIProvider(
+    const { getByRole } = await renderWithNexUIProvider(
       <CardActionArea onClick={handleClick}>Click me</CardActionArea>,
       {
         useAct: true,
@@ -35,21 +36,7 @@ describe('CardActionArea', () => {
     )
 
     const button = getByRole('button')
-    await user.click(button)
+    fireEvent.click(button)
     expect(handleClick).toHaveBeenCalledTimes(1)
-  })
-
-  it('should not handle click events when disabled', async () => {
-    const handleClick = jest.fn()
-    const { getByRole, user } = renderWithNexUIProvider(
-      <CardActionArea onClick={handleClick} disabled>
-        Click me
-      </CardActionArea>,
-    )
-
-    const button = getByRole('button')
-    await user.click(button)
-
-    expect(handleClick).not.toHaveBeenCalled()
   })
 })

--- a/packages/react/src/components/card/__tests__/__snapshots__/Card.test.tsx.snap
+++ b/packages/react/src/components/card/__tests__/__snapshots__/Card.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`Card should render with default props 1`] = `
 <div
   class="nui-card-root emotion-0"
   data-blurred="false"
+  data-disable-animation="false"
   data-hoverable="false"
   data-radius="md"
   data-shadow="md"

--- a/packages/react/src/components/card/types.ts
+++ b/packages/react/src/components/card/types.ts
@@ -56,6 +56,11 @@ interface CardOwnProps<RootComponent extends ElementType> {
    * If true, enables a hover effect on the Card.
    */
   hoverable?: boolean
+
+  /**
+   * If true, disables the animation for the Card on hover.
+   */
+  disableAnimation?: boolean
 }
 
 export type CardProps<RootComponent extends ElementType = 'div'> =
@@ -216,6 +221,13 @@ interface CardActionAreaOwnProps<RootComponent extends ElementType> {
    * Additional class names to apply to the root.
    */
   className?: ClassValue
+
+  /**
+   * If true, disables the ripple effect.
+   *
+   * @default false
+   */
+  disableRipple?: boolean
 }
 
 export type CardActionAreaProps<RootComponent extends ElementType = 'button'> =

--- a/packages/react/src/components/checkbox/__tests__/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/react/src/components/checkbox/__tests__/__snapshots__/Checkbox.test.tsx.snap
@@ -92,8 +92,6 @@ exports[`Checkbox should disable animations when disableAnimation=true 1`] = `
   inset: 0;
   border: var(--nui-borders-md);
   border-color: var(--nui-colors-gray-highlight);
-  -webkit-transition: none;
-  transition: none;
   background: transparent;
   z-index: -2;
   border-radius: calc(var(--nui-radii-lg) * .6);
@@ -104,12 +102,6 @@ exports[`Checkbox should disable animations when disableAnimation=true 1`] = `
   position: absolute;
   inset: 0;
   background-color: var(--nui-colors-blue-primary);
-  -webkit-transition: none;
-  transition: none;
-  -webkit-transform: none;
-  -moz-transform: none;
-  -ms-transform: none;
-  transform: none;
   opacity: 0;
   z-index: -1;
   border-radius: calc(var(--nui-radii-lg) * .6);
@@ -243,8 +235,6 @@ exports[`Checkbox should disable animations when disableAnimation=true 2`] = `
   inset: 0;
   border: var(--nui-borders-md);
   border-color: var(--nui-colors-gray-highlight);
-  -webkit-transition: none;
-  transition: none;
   background: transparent;
   z-index: -2;
   border-radius: calc(var(--nui-radii-lg) * .6);
@@ -255,15 +245,13 @@ exports[`Checkbox should disable animations when disableAnimation=true 2`] = `
   position: absolute;
   inset: 0;
   background-color: var(--nui-colors-blue-primary);
-  -webkit-transition: none;
-  transition: none;
-  -webkit-transform: none;
-  -moz-transform: none;
-  -ms-transform: none;
-  transform: none;
   opacity: 1;
   z-index: -1;
   border-radius: calc(var(--nui-radii-lg) * .6);
+  -webkit-transform: scale(1);
+  -moz-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
 }
 
 .emotion-3 {
@@ -411,11 +399,11 @@ exports[`Checkbox should render with default props 1`] = `
   inset: 0;
   border: var(--nui-borders-md);
   border-color: var(--nui-colors-gray-highlight);
-  -webkit-transition: var(--nui-transitions-colors);
-  transition: var(--nui-transitions-colors);
   background: transparent;
   z-index: -2;
   border-radius: calc(var(--nui-radii-lg) * .6);
+  -webkit-transition: var(--nui-transitions-colors);
+  transition: var(--nui-transitions-colors);
 }
 
 .emotion-2::after {
@@ -423,15 +411,15 @@ exports[`Checkbox should render with default props 1`] = `
   position: absolute;
   inset: 0;
   background-color: var(--nui-colors-blue-primary);
+  opacity: 0;
+  z-index: -1;
+  border-radius: calc(var(--nui-radii-lg) * .6);
   -webkit-transition: all 0.2s linear;
   transition: all 0.2s linear;
   -webkit-transform: scale(0.4);
   -moz-transform: scale(0.4);
   -ms-transform: scale(0.4);
   transform: scale(0.4);
-  opacity: 0;
-  z-index: -1;
-  border-radius: calc(var(--nui-radii-lg) * .6);
 }
 
 .emotion-3 {

--- a/packages/react/src/components/checkbox/__tests__/__snapshots__/CheckboxGroup.test.tsx.snap
+++ b/packages/react/src/components/checkbox/__tests__/__snapshots__/CheckboxGroup.test.tsx.snap
@@ -117,11 +117,11 @@ exports[`CheckboxGroup should render with default props 1`] = `
   inset: 0;
   border: var(--nui-borders-md);
   border-color: var(--nui-colors-gray-highlight);
-  -webkit-transition: var(--nui-transitions-colors);
-  transition: var(--nui-transitions-colors);
   background: transparent;
   z-index: -2;
   border-radius: calc(var(--nui-radii-lg) * .6);
+  -webkit-transition: var(--nui-transitions-colors);
+  transition: var(--nui-transitions-colors);
 }
 
 .emotion-4::after {
@@ -129,15 +129,15 @@ exports[`CheckboxGroup should render with default props 1`] = `
   position: absolute;
   inset: 0;
   background-color: var(--nui-colors-blue-primary);
+  opacity: 0;
+  z-index: -1;
+  border-radius: calc(var(--nui-radii-lg) * .6);
   -webkit-transition: all 0.2s linear;
   transition: all 0.2s linear;
   -webkit-transform: scale(0.4);
   -moz-transform: scale(0.4);
   -ms-transform: scale(0.4);
   transform: scale(0.4);
-  opacity: 0;
-  z-index: -1;
-  border-radius: calc(var(--nui-radii-lg) * .6);
 }
 
 .emotion-5 {

--- a/packages/react/src/components/dialog/DialogContent.tsx
+++ b/packages/react/src/components/dialog/DialogContent.tsx
@@ -43,13 +43,13 @@ export function DialogContent<RootComponent extends ElementType = 'div'>(
     hideBackdrop,
     container,
     keepMounted,
-    disableAnimation,
     preventScroll,
     restoreFocus,
     autoFocus,
     closeOnEscape,
     'aria-labelledby': ariaLabelledBy,
     'aria-describedby': ariaDescribedBy,
+    disableAnimation = false,
     placement = 'top',
     scroll = 'outside',
     hideCloseButton = false,
@@ -64,6 +64,7 @@ export function DialogContent<RootComponent extends ElementType = 'div'>(
     scroll,
     size,
     hideCloseButton,
+    disableAnimation,
   }
 
   const { open } = useDialogContext()

--- a/packages/react/src/components/drawer/DrawerContent.tsx
+++ b/packages/react/src/components/drawer/DrawerContent.tsx
@@ -39,7 +39,6 @@ export function DrawerContent<RootComponent extends ElementType = 'div'>(
     slotProps,
     closeIcon,
     motionProps,
-    disableAnimation,
     restoreFocus,
     closeOnEscape,
     hideBackdrop,
@@ -50,6 +49,7 @@ export function DrawerContent<RootComponent extends ElementType = 'div'>(
     placement = 'right',
     hideCloseButton = false,
     closeOnInteractOutside = true,
+    disableAnimation = false,
     size = 'md',
     ...remainingProps
   } = props
@@ -70,6 +70,7 @@ export function DrawerContent<RootComponent extends ElementType = 'div'>(
     size,
     closeIcon,
     hideCloseButton,
+    disableAnimation,
   }
 
   const styles = useRecipeStyles({

--- a/packages/react/src/components/dropdown/DropdownContent.tsx
+++ b/packages/react/src/components/dropdown/DropdownContent.tsx
@@ -35,11 +35,11 @@ export function DropdownContent<RootComponent extends ElementType>(
     container,
     keepMounted,
     motionProps,
-    disableAnimation,
     slotProps,
     classNames,
     minWidth,
     maxHeight,
+    disableAnimation = false,
     color = 'gray',
     variant = 'solid',
     placement = 'bottom',
@@ -99,8 +99,9 @@ export function DropdownContent<RootComponent extends ElementType>(
       variant,
       indicatorsCount,
       setIndicatorsCount,
+      disableAnimation,
     }),
-    [color, indicatorsCount, variant],
+    [color, disableAnimation, indicatorsCount, variant],
   )
 
   const renderPaper = () => (

--- a/packages/react/src/components/dropdown/DropdownContext.tsx
+++ b/packages/react/src/components/dropdown/DropdownContext.tsx
@@ -33,6 +33,7 @@ export interface DropdownContentContextValue {
   setIndicatorsCount: Dispatch<SetStateAction<number>>
   color: DropdownContentProps['color']
   variant: DropdownContentProps['variant']
+  disableAnimation: DropdownContentProps['disableAnimation']
 }
 
 export const [DropdownContentProvider, useDropdownContentContext] =

--- a/packages/react/src/components/dropdown/DropdownItem.tsx
+++ b/packages/react/src/components/dropdown/DropdownItem.tsx
@@ -30,8 +30,11 @@ export function DropdownItemImpl(inProps: DropdownItemImplProps) {
     props: inProps,
   })
 
-  const { color: defaultColor, variant: defaultVariant } =
-    useDropdownContentContext()
+  const {
+    disableAnimation,
+    color: defaultColor,
+    variant: defaultVariant,
+  } = useDropdownContentContext()
 
   const {
     children,
@@ -56,6 +59,7 @@ export function DropdownItemImpl(inProps: DropdownItemImplProps) {
     color,
     variant,
     hasIndicator,
+    disableAnimation,
   }
 
   const styles = useRecipeStyles({

--- a/packages/react/src/components/dropdown/SubDropdownContent.tsx
+++ b/packages/react/src/components/dropdown/SubDropdownContent.tsx
@@ -36,19 +36,22 @@ export function SubDropdownContent<RootComponent extends ElementType>(
 
   const { open } = useSubDropdownContext()
 
-  const { color: defaultColor, variant: defaultVariant } =
-    useDropdownContentContext()
+  const {
+    color: defaultColor,
+    variant: defaultVariant,
+    disableAnimation: defaultDisableAnimation,
+  } = useDropdownContentContext()
 
   const {
     children,
     container,
     keepMounted,
     motionProps,
-    disableAnimation,
     classNames,
     slotProps,
     minWidth,
     maxHeight,
+    disableAnimation = defaultDisableAnimation,
     color = defaultColor,
     variant = defaultVariant,
     ...remainingProps
@@ -104,8 +107,9 @@ export function SubDropdownContent<RootComponent extends ElementType>(
       variant,
       indicatorsCount,
       setIndicatorsCount,
+      disableAnimation,
     }),
-    [color, indicatorsCount, variant],
+    [color, disableAnimation, indicatorsCount, variant],
   )
 
   const renderPaper = () => (

--- a/packages/react/src/components/input/__tests__/__snapshots__/Input.test.tsx.snap
+++ b/packages/react/src/components/input/__tests__/__snapshots__/Input.test.tsx.snap
@@ -3,8 +3,6 @@
 exports[`Input should render with default props 1`] = `
 .emotion-0 {
   box-sizing: border-box;
-  -webkit-transition: var(--nui-transitions-colors);
-  transition: var(--nui-transitions-colors);
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -25,6 +23,8 @@ exports[`Input should render with default props 1`] = `
   border-radius: var(--nui-radii-lg);
   border: var(--nui-borders-md);
   border-color: var(--nui-colors-gray-highlight);
+  -webkit-transition: var(--nui-transitions-colors);
+  transition: var(--nui-transitions-colors);
 }
 
 .emotion-0:is(:hover, [data-hover=true]):not(:disabled, [data-disabled=true]) {

--- a/packages/react/src/components/radioGroup/__tests__/__snapshots__/Radio.test.tsx.snap
+++ b/packages/react/src/components/radioGroup/__tests__/__snapshots__/Radio.test.tsx.snap
@@ -87,10 +87,10 @@ exports[`Radio should render with default props 1`] = `
   -webkit-justify-content: center;
   justify-content: center;
   box-sizing: border-box;
-  -webkit-transition: var(--nui-transitions-colors);
-  transition: var(--nui-transitions-colors);
   width: var(--nui-sizes-5);
   height: var(--nui-sizes-5);
+  -webkit-transition: var(--nui-transitions-colors);
+  transition: var(--nui-transitions-colors);
 }
 
 .emotion-2::before {
@@ -102,10 +102,10 @@ exports[`Radio should render with default props 1`] = `
   transform: scale(0);
   border-radius: var(--nui-radii-full);
   background-color: var(--nui-colors-blue-primary);
-  -webkit-transition: var(--nui-transitions-all);
-  transition: var(--nui-transitions-all);
   width: var(--nui-sizes-2);
   height: var(--nui-sizes-2);
+  -webkit-transition: var(--nui-transitions-all);
+  transition: var(--nui-transitions-all);
 }
 
 .emotion-3 {

--- a/packages/react/src/components/radioGroup/__tests__/__snapshots__/RadioGroup.test.tsx.snap
+++ b/packages/react/src/components/radioGroup/__tests__/__snapshots__/RadioGroup.test.tsx.snap
@@ -116,10 +116,10 @@ exports[`RadioGroup should render with default props 1`] = `
   -webkit-justify-content: center;
   justify-content: center;
   box-sizing: border-box;
-  -webkit-transition: var(--nui-transitions-colors);
-  transition: var(--nui-transitions-colors);
   width: var(--nui-sizes-5);
   height: var(--nui-sizes-5);
+  -webkit-transition: var(--nui-transitions-colors);
+  transition: var(--nui-transitions-colors);
 }
 
 .emotion-4::before {
@@ -131,10 +131,10 @@ exports[`RadioGroup should render with default props 1`] = `
   transform: scale(0);
   border-radius: var(--nui-radii-full);
   background-color: var(--nui-colors-blue-primary);
-  -webkit-transition: var(--nui-transitions-all);
-  transition: var(--nui-transitions-all);
   width: var(--nui-sizes-2);
   height: var(--nui-sizes-2);
+  -webkit-transition: var(--nui-transitions-all);
+  transition: var(--nui-transitions-all);
 }
 
 .emotion-5 {

--- a/packages/react/src/components/switch/__tests__/__snapshots__/Switch.test.tsx.snap
+++ b/packages/react/src/components/switch/__tests__/__snapshots__/Switch.test.tsx.snap
@@ -69,8 +69,6 @@ exports[`Switch should render with default props 1`] = `
   -ms-flex-align: center;
   align-items: center;
   box-sizing: border-box;
-  -webkit-transition: var(--nui-transitions-colors);
-  transition: var(--nui-transitions-colors);
   overflow: hidden;
   position: relative;
   -webkit-padding-start: var(--nui-spaces-1);
@@ -80,6 +78,8 @@ exports[`Switch should render with default props 1`] = `
   width: var(--nui-sizes-12);
   height: var(--nui-sizes-7);
   font-size: var(--nui-font-sizes-lg);
+  -webkit-transition: var(--nui-transitions-colors);
+  transition: var(--nui-transitions-colors);
 }
 
 [data-nui-color-scheme="dark"] .emotion-2 {
@@ -89,8 +89,6 @@ exports[`Switch should render with default props 1`] = `
 .emotion-3 {
   background-color: var(--nui-colors-white);
   border-radius: inherit;
-  -webkit-transition: var(--nui-transitions-margin);
-  transition: var(--nui-transitions-margin);
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -105,6 +103,8 @@ exports[`Switch should render with default props 1`] = `
   align-items: center;
   width: var(--nui-sizes-5);
   height: var(--nui-sizes-5);
+  -webkit-transition: var(--nui-transitions-margin);
+  transition: var(--nui-transitions-margin);
 }
 
 <label

--- a/packages/react/src/theme/recipes/breadcrumb.ts
+++ b/packages/react/src/theme/recipes/breadcrumb.ts
@@ -113,6 +113,7 @@ export const breadcrumbItemRecipe = defineSlotRecipe({
       color: 'colorPalette.primary/70',
       userSelect: 'none',
       borderRadius: 2,
+      whiteSpace: 'nowrap',
       _focusVisibleRing: {
         outline: '{borders.md} {colors.colorPalette.primary}',
         outlineOffset: '2px',

--- a/packages/react/src/theme/recipes/card.ts
+++ b/packages/react/src/theme/recipes/card.ts
@@ -50,7 +50,6 @@ export const cardRecipe = defineRecipe({
     },
     hoverable: {
       true: {
-        transition: 'scale',
         _hover: {
           scale: '1.03',
         },
@@ -59,7 +58,19 @@ export const cardRecipe = defineRecipe({
         },
       },
     },
+    disableAnimation: {
+      false: {},
+    },
   },
+  compoundVariants: [
+    {
+      disableAnimation: false,
+      hoverable: true,
+      css: {
+        transition: 'scale',
+      },
+    },
+  ],
 })
 
 export const cardHeaderRecipe = defineSlotRecipe({
@@ -134,6 +145,8 @@ export const cardActionArea = defineRecipe({
     disabled: {
       true: {
         cursor: 'default',
+        pointerEvents: 'none',
+        opacity: 0.6,
       },
     },
   },

--- a/packages/react/src/theme/recipes/checkbox.ts
+++ b/packages/react/src/theme/recipes/checkbox.ts
@@ -68,8 +68,6 @@ export const checkboxRecipe = defineSlotRecipe({
     },
     checkedIcon: {
       opacity: 0,
-      transition: 'all 0.2s linear',
-      transform: 'scale(0.4)',
     },
     icon: {
       display: 'inline-flex',
@@ -83,7 +81,6 @@ export const checkboxRecipe = defineSlotRecipe({
         inset: 0,
         border: 'md',
         borderColor: 'gray.highlight',
-        transition: 'colors',
         background: 'transparent',
         zIndex: -2,
       },
@@ -92,14 +89,29 @@ export const checkboxRecipe = defineSlotRecipe({
         position: 'absolute',
         inset: 0,
         bg: 'colorPalette.primary',
-        transition: 'all 0.2s linear',
-        transform: 'scale(0.4)',
         opacity: 0,
         zIndex: -1,
       },
     },
   },
   variants: {
+    disableAnimation: {
+      false: {
+        checkedIcon: {
+          transition: 'all 0.2s linear',
+          transform: 'scale(0.4)',
+        },
+        icon: {
+          '::before': {
+            transition: 'colors',
+          },
+          '::after': {
+            transition: 'all 0.2s linear',
+            transform: 'scale(0.4)',
+          },
+        },
+      },
+    },
     checked: {
       true: {
         checkedIcon: {
@@ -225,23 +237,6 @@ export const checkboxRecipe = defineSlotRecipe({
     inGroup: {
       true: {
         root: {},
-      },
-    },
-    disableAnimation: {
-      true: {
-        checkedIcon: {
-          transition: 'none',
-          transform: 'none',
-        },
-        icon: {
-          '::before': {
-            transition: 'none',
-          },
-          '::after': {
-            transition: 'none',
-            transform: 'none',
-          },
-        },
       },
     },
   },

--- a/packages/react/src/theme/recipes/dialog.ts
+++ b/packages/react/src/theme/recipes/dialog.ts
@@ -28,7 +28,6 @@ export const dialogContentRecipe = defineSlotRecipe({
       p: '1.5',
       overflow: 'hidden',
       borderRadius: 'full',
-      transition: 'colors',
       color: 'gray.400',
       _hover: {
         bg: 'gray.muted',
@@ -104,6 +103,13 @@ export const dialogContentRecipe = defineSlotRecipe({
       bottom: {
         root: {
           alignItems: 'flex-end',
+        },
+      },
+    },
+    disableAnimation: {
+      false: {
+        closeButton: {
+          transition: 'colors',
         },
       },
     },

--- a/packages/react/src/theme/recipes/drawer.ts
+++ b/packages/react/src/theme/recipes/drawer.ts
@@ -28,7 +28,7 @@ export const drawerContentRecipe = defineSlotRecipe({
       p: '1.5',
       overflow: 'hidden',
       borderRadius: 'full',
-      transition: 'colors',
+
       color: 'gray.400',
       _hover: {
         bg: 'gray.muted',
@@ -94,6 +94,13 @@ export const drawerContentRecipe = defineSlotRecipe({
           borderTopRightRadius: 0,
           borderBottomLeftRadius: 0,
           borderBottomRightRadius: 0,
+        },
+      },
+    },
+    disableAnimation: {
+      false: {
+        closeButton: {
+          transition: 'colors',
         },
       },
     },

--- a/packages/react/src/theme/recipes/dropdown.ts
+++ b/packages/react/src/theme/recipes/dropdown.ts
@@ -35,7 +35,6 @@ export const dropdownItemRecipe = defineSlotRecipe({
       pl: '2',
       pr: '2',
       borderRadius: 'sm',
-      transition: 'colors',
       color: 'inherit',
       textDecoration: 'none',
       _disabled: {
@@ -53,7 +52,6 @@ export const dropdownItemRecipe = defineSlotRecipe({
       opacity: 0.5,
       letterSpacing: 1,
       fontFamily: 'inherit',
-      transition: 'colors',
       "[data-highlighted='true'] > &": {
         opacity: 1,
       },
@@ -129,6 +127,16 @@ export const dropdownItemRecipe = defineSlotRecipe({
       },
     },
     color: toSlots(colorVariant, 'root'),
+    disableAnimation: {
+      false: {
+        root: {
+          transition: 'colors',
+        },
+        shortcut: {
+          transition: 'colors',
+        },
+      },
+    },
   },
 })
 

--- a/packages/react/src/theme/recipes/input.ts
+++ b/packages/react/src/theme/recipes/input.ts
@@ -14,7 +14,6 @@ export const inputRecipe = defineSlotRecipe({
   slots: {
     root: {
       boxSizing: 'border-box',
-      transition: 'colors',
       display: 'inline-flex',
       alignItems: 'center',
       gap: '1',
@@ -46,10 +45,8 @@ export const inputRecipe = defineSlotRecipe({
     },
     label: {
       position: 'absolute',
-      transformOrigin: 'top left',
       pointerEvents: 'none',
-      transitionProperty: 'inset, color, transform',
-      transitionDuration: '0.2s',
+      transformOrigin: 'top left',
     },
     prefix: {
       display: 'flex',
@@ -156,7 +153,6 @@ export const inputRecipe = defineSlotRecipe({
             w: '100%',
             h: '2px',
             bg: 'gray.highlight',
-            transition: 'colors',
           },
           '::after': {
             content: '""',
@@ -167,7 +163,6 @@ export const inputRecipe = defineSlotRecipe({
             width: 0,
             h: '2px',
             bg: 'colorPalette.primary',
-            transition: 'width 0.2s ease',
           },
           _focusWithin: {
             '::after': {
@@ -223,18 +218,13 @@ export const inputRecipe = defineSlotRecipe({
       },
     },
     disableAnimation: {
-      true: {
+      false: {
         root: {
-          transition: 'none',
-          '::before': {
-            transition: 'none',
-          },
-          '::after': {
-            transition: 'none',
-          },
+          transition: 'colors',
         },
         label: {
-          transition: 'none',
+          transitionProperty: 'inset, color, transform',
+          transitionDuration: '0.2s',
         },
       },
     },
@@ -447,6 +437,20 @@ export const inputRecipe = defineSlotRecipe({
         },
         input: {
           color: 'red.primary',
+        },
+      },
+    },
+    {
+      disableAnimation: false,
+      variant: 'underlined',
+      css: {
+        root: {
+          '::before': {
+            transition: 'colors',
+          },
+          '::after': {
+            transition: 'width 0.2s ease',
+          },
         },
       },
     },

--- a/packages/react/src/theme/recipes/radioGroup.ts
+++ b/packages/react/src/theme/recipes/radioGroup.ts
@@ -44,7 +44,6 @@ export const radioRecipe = defineSlotRecipe({
       alignItems: 'center',
       justifyContent: 'center',
       boxSizing: 'border-box',
-      transition: 'colors',
 
       '::before': {
         content: '""',
@@ -52,7 +51,6 @@ export const radioRecipe = defineSlotRecipe({
         transform: 'scale(0)',
         borderRadius: 'full',
         backgroundColor: 'colorPalette.primary',
-        transition: 'all',
       },
     },
     label: {
@@ -129,11 +127,11 @@ export const radioRecipe = defineSlotRecipe({
       true: {},
     },
     disableAnimation: {
-      true: {
+      false: {
         indicator: {
-          transition: 'none',
+          transition: 'colors',
           '::before': {
-            transition: 'none',
+            transition: 'all',
           },
         },
       },

--- a/packages/react/src/theme/recipes/switch.ts
+++ b/packages/react/src/theme/recipes/switch.ts
@@ -34,7 +34,6 @@ export const switchRecipe = defineSlotRecipe({
       borderRadius: 'full',
       alignItems: 'center',
       boxSizing: 'border-box',
-      transition: 'colors',
       overflow: 'hidden',
       position: 'relative',
       px: '1',
@@ -42,7 +41,6 @@ export const switchRecipe = defineSlotRecipe({
     thumb: {
       bg: 'white',
       borderRadius: 'inherit',
-      transition: 'margin',
       display: 'flex',
       justifyContent: 'center',
       alignItems: 'center',
@@ -52,7 +50,6 @@ export const switchRecipe = defineSlotRecipe({
       alignItems: 'center',
       justifyContent: 'center',
       position: 'absolute',
-      transition: 'scale',
       insetInlineStart: '1',
       opacity: 0,
       scale: 0,
@@ -62,7 +59,6 @@ export const switchRecipe = defineSlotRecipe({
       alignItems: 'center',
       justifyContent: 'center',
       position: 'absolute',
-      transition: 'transform',
       insetInlineEnd: '1',
     },
     label: {
@@ -159,18 +155,18 @@ export const switchRecipe = defineSlotRecipe({
     },
     disabled: toSlots(disabledVariant, 'root'),
     disableAnimation: {
-      true: {
+      false: {
         track: {
-          transition: 'none',
+          transition: 'colors',
         },
         thumb: {
-          transition: 'none',
+          transition: 'margin',
         },
         startIcon: {
-          transition: 'none',
+          transition: 'scale',
         },
         endIcon: {
-          transition: 'none',
+          transition: 'transform',
         },
       },
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Card: new disableAnimation prop to turn off hover animations.
  * CardActionArea: new disabled and disableRipple props to control interactivity and ripple effects.

* **Bug Fixes**
  * Breadcrumb links no longer wrap.
  * CardActionArea disabled state shows visual feedback (reduced opacity, no pointer events).

* **Improvements**
  * Animation control unified across components via disableAnimation.

* **Documentation**
  * Updated English/Chinese docs and Storybook controls for new props.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->